### PR TITLE
HW 8

### DIFF
--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 @Service
-class OrderPayer {
+class OrderPayer (adapters: List<PaymentExternalSystemAdapter>) {
 
     companion object {
         val logger: Logger = LoggerFactory.getLogger(OrderPayer::class.java)
@@ -26,9 +26,14 @@ class OrderPayer {
     @Autowired
     private lateinit var paymentService: PaymentService
 
+    private val defaultAdapter = adapters.first() as? PaymentExternalSystemAdapterImpl
+    private val properties = defaultAdapter!!.properties
+
+    val maxThreads = properties.parallelRequests
+
     private val paymentExecutor = ThreadPoolExecutor(
-        16,
-        16,
+        maxThreads,
+        maxThreads,
         0L,
         TimeUnit.MILLISECONDS,
         LinkedBlockingQueue(8_000),


### PR DESCRIPTION
Заменили ограничение в 16 на то, которое идёт в аккаунте провайдера. То есть, количество одновременных запросов у нас то же, что и у провайдера. 

<img width="1864" height="798" alt="image" src="https://github.com/user-attachments/assets/4357ed2f-4a65-4515-8f27-a384479305ab" />
