### PR TITLE
HW 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-eclipse-temurin-17 AS build
+FROM maven:3.9.9-eclipse-temurin-21 AS build
 
 WORKDIR /app
 COPY pom.xml .
@@ -6,9 +6,9 @@ RUN mvn dependency:go-offline
 COPY src src
 RUN mvn package
 
-FROM eclipse-temurin:17-alpine-3.22
+FROM eclipse-temurin:21-alpine
 
 COPY --from=build /app/target/*.jar /high-load-course.jar
 
-CMD ["java", "-jar", "/high-load-course.jar"]
+CMD ["java", "-Djdk.virtualThreadScheduler.parallelism=1024", "-Djdk.virtualThreadScheduler.maxPoolSize=1024", "-jar", "/high-load-course.jar"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>17</jvmTarget>
+                    <jvmTarget>21</jvmTarget>
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -213,8 +213,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import ru.quipy.apigateway.exceptions.RateLimitException
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.metrics.MetricsService
 import ru.quipy.orders.repository.OrderRepository
@@ -32,7 +31,7 @@ class APIController(
     @PostConstruct
     fun init() {
         val limit = orderPayer.getMaxRateLimit()
-        this.rateLimiter = SlidingWindowRateLimiter((limit * 4L / 5), Duration.ofSeconds(1))
+        this.rateLimiter = SlidingWindowRateLimiter((limit * 4L / 5) / 10, Duration.ofMillis(100))
     }
 
     @PostMapping("/users")

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import ru.quipy.apigateway.exceptions.RateLimitException
-import ru.quipy.common.utils.LeakingBucketRateLimiter
+import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.metrics.MetricsService
 import ru.quipy.orders.repository.OrderRepository
 import ru.quipy.payments.logic.OrderPayer
@@ -27,12 +27,12 @@ class APIController(
     @Autowired
     private lateinit var orderPayer: OrderPayer
 
-    private lateinit var rateLimiter: LeakingBucketRateLimiter
+    private lateinit var rateLimiter: SlidingWindowRateLimiter
 
     @PostConstruct
     fun init() {
         val limit = orderPayer.getMaxRateLimit()
-        this.rateLimiter = LeakingBucketRateLimiter(limit.toLong(), Duration.ofSeconds(1), 400)
+        this.rateLimiter = SlidingWindowRateLimiter((limit * 4L / 5), Duration.ofSeconds(1))
     }
 
     @PostMapping("/users")

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -1,32 +1,24 @@
 package ru.quipy.apigateway
 
+import jakarta.annotation.PostConstruct
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import ru.quipy.common.utils.*
+import ru.quipy.apigateway.exceptions.RateLimitException
+import ru.quipy.common.utils.LeakingBucketRateLimiter
+import ru.quipy.metrics.MetricsService
 import ru.quipy.orders.repository.OrderRepository
 import ru.quipy.payments.logic.OrderPayer
-import ru.quipy.payments.logic.PaymentExternalSystemAdapter
-import ru.quipy.payments.logic.PaymentExternalSystemAdapterImpl
-import java.time.Duration.ofMillis
-import java.time.Duration.ofSeconds
-import java.util.*
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
-import ru.quipy.metrics.MetricsService
 import java.time.Duration
+import java.util.*
 
 @RestController
 class APIController(
-    val metricsService: MetricsService,
-    adapters: List<PaymentExternalSystemAdapter>
+    private val metricsService: MetricsService
 ) {
-    private val defaultAdapter = adapters.first() as? PaymentExternalSystemAdapterImpl
-    private val properties = defaultAdapter!!.properties
-
     val logger: Logger = LoggerFactory.getLogger(APIController::class.java)
 
     @Autowired
@@ -35,29 +27,13 @@ class APIController(
     @Autowired
     private lateinit var orderPayer: OrderPayer
 
-    private val retryCounters = ConcurrentHashMap<UUID, Pair<Int, Long>>()
-    private val maxRetries = 2
-    private val retryWindowMs = 60_000L
+    private lateinit var rateLimiter: LeakingBucketRateLimiter
 
-
-    private val slidingWindow = SlidingWindowRateLimiter(
-        rate = 10,
-        window = ofSeconds(1)
-    )
-    
-    private val leakingBucket = LeakingBucketRateLimiter(
-        rate = 10,
-        bucketSize = 38,
-        window = ofMillis(1000)
-    )
-    
-    private val compositeRateLimiter = CompositeRateLimiter(
-        rl1 = slidingWindow,
-        rl2 = leakingBucket,
-        mode = CompositeMode.AND
-    )
-
-    private val paymentRateLimiter = SlidingWindowRateLimiter(11, Duration.ofSeconds(1))
+    @PostConstruct
+    fun init() {
+        val limit = orderPayer.getMaxRateLimit()
+        this.rateLimiter = LeakingBucketRateLimiter(limit.toLong(), Duration.ofSeconds(1), 400)
+    }
 
     @PostMapping("/users")
     fun createUser(@RequestBody req: CreateUserRequest): User {
@@ -95,53 +71,22 @@ class APIController(
     }
 
     @PostMapping("/orders/{orderId}/payment")
-    fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): ResponseEntity<*> {
-        val now = System.currentTimeMillis()
-
-        val (count, lastTime) = retryCounters[orderId] ?: (0 to now)
-        if (now - lastTime > retryWindowMs) {
-            retryCounters[orderId] = (1 to now)
-        } else if (count >= maxRetries) {
-            logger.debug("Too many retries for order {}", orderId)
+    suspend fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): ResponseEntity<PaymentSubmissionDto> {
+        if (!rateLimiter.tick()) {
             return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
-                .body(mapOf("error" to "Too many retries for order $orderId"))
-        } else {
-            retryCounters[orderId] = (count + 1 to now)
-        }
-
-        val remaining = deadline - now
-        val avgProcessingMs = properties.averageProcessingTime.toMillis()
-        if (remaining < avgProcessingMs) {
-            logger.debug("Deadline too close, skipping payment for order {} (remaining={} ms)", orderId, remaining)
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(mapOf("error" to "Deadline too close — payment no longer meaningful"))
-        }
-
-        if (!compositeRateLimiter.tick()) {
-            logger.debug("Rate limit exceeded for payment request of {}", orderId)
-
-            val retryAfterMs = 500L
-            return if (remaining > avgProcessingMs + retryAfterMs) {
-                ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
-                    .header("X-Retry-After-Ms", retryAfterMs.toString())
-                    .body(mapOf("error" to "Rate limit exceeded, retry after $retryAfterMs ms"))
-            } else {
-                ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
-                    .body(mapOf("error" to "Rate limit exceeded and deadline too close"))
-            }
+                .header("Retry-After", 1.toString())
+                .build()
         }
 
         val paymentId = UUID.randomUUID()
         val order = orderRepository.findById(orderId)?.let {
             orderRepository.save(it.copy(status = OrderStatus.PAYMENT_IN_PROGRESS))
             it
-        } ?: return ResponseEntity.status(HttpStatus.NOT_FOUND)
-            .body(mapOf("error" to "No such order $orderId"))
+        } ?: throw IllegalArgumentException("No such order $orderId")
 
         val createdAt = orderPayer.processPayment(orderId, order.price, paymentId, deadline)
         return ResponseEntity.ok(PaymentSubmissionDto(createdAt, paymentId))
     }
-
 
     class PaymentSubmissionDto(
         val timestamp: Long,

--- a/src/main/kotlin/ru/quipy/apigateway/exceptions/RateLimitException.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/exceptions/RateLimitException.kt
@@ -1,0 +1,3 @@
+package ru.quipy.apigateway.exceptions
+
+class RateLimitException : RuntimeException()

--- a/src/main/kotlin/ru/quipy/common/utils/CustomPolicy.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/CustomPolicy.kt
@@ -21,7 +21,8 @@ class CallerBlockingRejectedExecutionHandler(
                 val queue = executor.queue
                 val offer = queue.offer(r, maxWait.toMillis(), TimeUnit.MILLISECONDS)
                 if (!offer) {
-                    throw RejectedExecutionException("Max wait time expired to queue task")
+                    logger.warn("Task rejected: queue overloaded (size={}, active={}, pool={})", queue.size, executor.activeCount, executor.poolSize)
+                    throw RejectedExecutionException("Queue overloaded: max wait ${maxWait.toMillis()}ms expired")
                 }
             } catch (e: InterruptedException) {
                 Thread.currentThread().interrupt()

--- a/src/main/kotlin/ru/quipy/common/utils/NonBlockingOngoingWindow.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/NonBlockingOngoingWindow.kt
@@ -4,12 +4,17 @@ import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicInteger
 
 class OngoingWindow(
-    maxWinSize: Int
+    maxWinSize: Int,
+    fair: Boolean = false
 ) {
-    private val window = Semaphore(maxWinSize)
+    private val window = Semaphore(maxWinSize, fair)
 
     fun acquire() {
         window.acquire()
+    }
+
+    fun tryAcquire(timeout: Long, unit: java.util.concurrent.TimeUnit): Boolean {
+        return window.tryAcquire(timeout, unit)
     }
 
     fun release() = window.release()

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -7,11 +7,9 @@ import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
-import java.util.concurrent.PriorityBlockingQueue
 import java.util.concurrent.atomic.AtomicLong
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 
 class SlidingWindowRateLimiter(
     private val rate: Long,
@@ -20,14 +18,14 @@ class SlidingWindowRateLimiter(
     private val rateLimiterScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
 
     private val sum = AtomicLong(0)
-    private val queue = PriorityBlockingQueue<Measure>(10_000)
+    private val queue = ConcurrentLinkedQueue<Long>()
 
     override fun tick(): Boolean {
         while (true) {
             val curSum = sum.get()
             if (curSum >= rate) return false
             if (sum.compareAndSet(curSum, curSum + 1)) {
-                queue.add(Measure(1, System.currentTimeMillis()))
+                queue.add(System.currentTimeMillis())
                 return true
             }
         }
@@ -39,31 +37,30 @@ class SlidingWindowRateLimiter(
         }
     }
 
-    data class Measure(
-        val value: Long,
-        val timestamp: Long
-    ) : Comparable<Measure> {
-        override fun compareTo(other: Measure): Int {
-            return timestamp.compareTo(other.timestamp)
+    fun tickBlocking(timeout: Duration): Boolean {
+        val deadlineNanos = System.nanoTime() + timeout.toNanos()
+        while (!tick()) {
+            if (System.nanoTime() >= deadlineNanos) return false
+            Thread.sleep(10)
         }
+        return true
     }
 
     private val releaseJob = rateLimiterScope.launch {
         while (true) {
-            val head = queue.peek()
             val winStart = System.currentTimeMillis() - window.toMillis()
-            if (head == null) {
-                delay(1L)
-                continue
+            var released = 0
+            while (true) {
+                val head = queue.peek() ?: break
+                if (head > winStart) break
+                queue.poll()
+                released++
             }
-            if (head.timestamp > winStart) {
-                delay(head.timestamp - winStart)
-                continue
-            }
-            sum.addAndGet(-1)
-            queue.take()
+            if (released > 0) sum.addAndGet(-released.toLong())
+            delay(1L)
         }
     }.invokeOnCompletion { th -> if (th != null) logger.error("Rate limiter release job completed", th) }
+
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(SlidingWindowRateLimiter::class.java)
     }

--- a/src/main/kotlin/ru/quipy/config/EventSourcingLibConfiguration.kt
+++ b/src/main/kotlin/ru/quipy/config/EventSourcingLibConfiguration.kt
@@ -1,18 +1,25 @@
 package ru.quipy.config
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import com.zaxxer.hikari.HikariDataSource
 import jakarta.annotation.PostConstruct
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.config.BeanPostProcessor
 import org.springframework.boot.web.embedded.jetty.JettyServerCustomizer
 import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.stereotype.Component
 import ru.quipy.core.EventSourcingServiceFactory
 import ru.quipy.payments.api.PaymentAggregate
 import ru.quipy.payments.logic.PaymentAggregateState
+import ru.quipy.common.utils.NamedThreadFactory
 import ru.quipy.streams.AggregateEventStreamManager
 import java.util.*
+import java.util.concurrent.Executors
 
 
 /**
@@ -52,6 +59,12 @@ class EventSourcingLibConfiguration {
     @Bean
     fun paymentsEsService() = eventSourcingServiceFactory.create<UUID, PaymentAggregate, PaymentAggregateState>()
 
+    @Bean
+    fun dbScope(): CoroutineScope {
+        val dbThreadPool = Executors.newFixedThreadPool(200, NamedThreadFactory("db-executor"))
+        return CoroutineScope(dbThreadPool.asCoroutineDispatcher())
+    }
+
     @PostConstruct
     fun init() {
         // Demonstrates how you can set up the listeners to the event stream
@@ -76,5 +89,20 @@ class EventSourcingLibConfiguration {
 
         jettyServletWebServerFactory.serverCustomizers.add(c)
         return jettyServletWebServerFactory
+    }
+}
+
+@Component
+class HikariDataSourceConfigurer : BeanPostProcessor {
+    private val logger = LoggerFactory.getLogger(HikariDataSourceConfigurer::class.java)
+
+    override fun postProcessAfterInitialization(bean: Any, beanName: String): Any {
+        if (bean is HikariDataSource) {
+            bean.maximumPoolSize = 400
+            bean.minimumIdle = 400
+            bean.connectionTimeout = 500
+            logger.info("HikariCP tuned: pool=${bean.maximumPoolSize}, connTimeout=${bean.connectionTimeout}ms, bean=$beanName")
+        }
+        return bean
     }
 }

--- a/src/main/kotlin/ru/quipy/metrics/MetricsService.kt
+++ b/src/main/kotlin/ru/quipy/metrics/MetricsService.kt
@@ -41,6 +41,21 @@ class MetricsService(
             .record(durationMs, TimeUnit.MILLISECONDS)
     }
 
+    fun incrementCounter(name: String, description: String = "") {
+        Counter.builder(name)
+            .description(description)
+            .register(Metrics.globalRegistry)
+            .increment()
+    }
+
+    fun incrementCounterWithTag(name: String, tagKey: String, tagValue: String, description: String = "") {
+        Counter.builder(name)
+            .description(description)
+            .tag(tagKey, tagValue)
+            .register(Metrics.globalRegistry)
+            .increment()
+    }
+
     private fun writeCounter(config: MetricsConfig.MetricProperties, tags: List<String>): Counter {
         val counterTags: List<Tag> =
             config.tags.mapIndexed { index, element ->

--- a/src/main/kotlin/ru/quipy/orders/subscribers/PaymentSubscriber.kt
+++ b/src/main/kotlin/ru/quipy/orders/subscribers/PaymentSubscriber.kt
@@ -34,14 +34,22 @@ class PaymentSubscriber {
             retryConf = RetryConf(1, RetryFailedStrategy.SKIP_EVENT)
         ) {
             `when`(PaymentProcessedEvent::class) { event ->
-                appExecutor.submit {
-                    logger.trace(
-                        "Payment results. OrderId ${event.orderId}, succeeded: ${event.success}, txId: ${event.transactionId}, reason: ${event.reason}, duration: ${
+                appExecutor.execute {
+                    try {
+                        logger.trace(
+                            "Payment results. OrderId {}, succeeded: {}, txId: {}, reason: {}, duration: {}, spent in queue: {}",
+                            event.orderId,
+                            event.success,
+                            event.transactionId,
+                            event.reason,
                             Duration.ofMillis(
                                 event.createdAt - event.submittedAt
-                            ).toSeconds()
-                        }, spent in queue: ${event.spentInQueueDuration.toSeconds()}"
-                    )
+                            ).toSeconds(),
+                            event.spentInQueueDuration.toSeconds()
+                        )
+                    } catch (e: Exception) {
+                        logger.error("Failed to handle PaymentProcessedEvent for orderId={}", event.orderId, e)
+                    }
                 }
             }
         }

--- a/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
+++ b/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
@@ -3,6 +3,7 @@ package ru.quipy.payments.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import kotlinx.coroutines.CoroutineScope
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -37,7 +38,7 @@ class PaymentAccountsConfig {
     lateinit var allowedAccounts: List<String>
 
     @Bean
-    fun accountAdapters(paymentService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>, metricsService: MetricsService,): List<PaymentExternalSystemAdapter> {
+    fun accountAdapters(paymentService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>, metricsService: MetricsService, dbScope: CoroutineScope): List<PaymentExternalSystemAdapter> {
         val request = HttpRequest.newBuilder()
             .uri(URI("http://${paymentProviderHostPort}/external/accounts?serviceName=$serviceName&token=$token"))
             .GET()
@@ -60,6 +61,7 @@ class PaymentAccountsConfig {
                     paymentProviderHostPort,
                     token,
                     metricsService,
+                    dbScope,
                 )
             }
     }

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -33,8 +33,8 @@ class OrderPayer(
     private lateinit var paymentESService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>
 
     private val paymentExecutor: ThreadPoolExecutor = ThreadPoolExecutor(
-        16,
-        16,
+        32,
+        32,
         0L,
         TimeUnit.MILLISECONDS,
         LinkedBlockingQueue(8_000),

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -1,5 +1,8 @@
 package ru.quipy.payments.logic
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -14,26 +17,24 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 @Service
-class OrderPayer (adapters: List<PaymentExternalSystemAdapter>) {
+class OrderPayer(
+    adapters: List<PaymentExternalSystemAdapter>,
+    private val dbScope: CoroutineScope
+) {
 
     companion object {
         val logger: Logger = LoggerFactory.getLogger(OrderPayer::class.java)
     }
 
     @Autowired
-    private lateinit var paymentESService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>
-
-    @Autowired
     private lateinit var paymentService: PaymentService
 
-    private val defaultAdapter = adapters.first() as? PaymentExternalSystemAdapterImpl
-    private val properties = defaultAdapter!!.properties
+    @Autowired
+    private lateinit var paymentESService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>
 
-    val maxThreads = properties.parallelRequests
-
-    private val paymentExecutor = ThreadPoolExecutor(
-        maxThreads,
-        maxThreads,
+    private val paymentExecutor: ThreadPoolExecutor = ThreadPoolExecutor(
+        16,
+        16,
         0L,
         TimeUnit.MILLISECONDS,
         LinkedBlockingQueue(8_000),
@@ -43,18 +44,26 @@ class OrderPayer (adapters: List<PaymentExternalSystemAdapter>) {
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
-        paymentExecutor.submit {
-            val createdEvent = paymentESService.create {
-                it.create(
-                    paymentId,
-                    orderId,
-                    amount
-                )
-            }
-            logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
 
-            paymentService.submitPaymentRequest(paymentId, amount, createdAt, deadline)
+        paymentExecutor.submit {
+            dbScope.launch {
+                while (true) {
+                    try {
+                        val createdEvent = paymentESService.create {
+                            it.create(paymentId, orderId, amount)
+                        }
+                        logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
+                        break
+                    } catch (_: IllegalArgumentException) {
+                        delay(10)
+                    }
+                }
+            }
+            paymentService.submitPaymentRequest(paymentId, amount, orderId, createdAt, deadline)
         }
+
         return createdAt
     }
+
+    fun getMaxRateLimit() = paymentService.getMaxRateLimit()
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -50,7 +50,7 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), Duration.ofSeconds(1))
+    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong() / 10, Duration.ofMillis(100))
     private val ongoingWindow = OngoingWindow(parallelRequests, false)
     private val latencyProfile = RollingLatencyProfile(maxSize = 2048, fallbackMs = requestAverageProcessingTime.coerceAtLeast(20L))
 
@@ -206,46 +206,38 @@ class PaymentExternalSystemAdapterImpl(
                 performPaymentAsync(paymentId, amount, paymentStartedAt, deadline, transactionId, attempt + 1)
             }
         }.exceptionally { ex ->
+            val willRetry = attempt + 1 < MAX_ATTEMPTS && now() + requestAverageProcessingTime <= deadline
             when (ex) {
                 is SocketTimeoutException -> {
                     logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", ex)
                     metricsService.incrementCounter("payment_failed_external", "Failed external requests")
-                    val currentTime = now()
-                    dbScope.launch {
-                        while (true) {
-                            try {
-                                paymentESService.update(paymentId) {
-                                    it.logProcessing(false, currentTime, transactionId, reason = "Request timeout.")
-                                }
-                                break
-                            } catch (_: IllegalArgumentException) {
-                                delay(10)
-                            }
-                        }
-                    }
                 }
                 else -> {
                     logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", ex)
                     metricsService.incrementCounter("payment_failed_external", "Failed external requests")
-                    val currentTime = now()
-                    dbScope.launch {
-                        while (true) {
-                            try {
-                                paymentESService.update(paymentId) {
-                                    it.logProcessing(false, currentTime, transactionId, reason = ex.message)
-                                }
-                                break
-                            } catch (_: IllegalArgumentException) {
-                                delay(10)
+                }
+            }
+            ongoingWindow.release()
+
+            if (willRetry) {
+                metricsService.increaseRetryCounter()
+                performPaymentAsync(paymentId, amount, paymentStartedAt, deadline, transactionId, attempt + 1)
+            } else {
+                val currentTime = now()
+                val reason = if (ex is SocketTimeoutException) "Request timeout." else ex.message
+                dbScope.launch {
+                    while (true) {
+                        try {
+                            paymentESService.update(paymentId) {
+                                it.logProcessing(false, currentTime, transactionId, reason = reason)
                             }
+                            break
+                        } catch (_: IllegalArgumentException) {
+                            delay(10)
                         }
                     }
                 }
             }
-            metricsService.increaseRetryCounter()
-            ongoingWindow.release()
-
-            performPaymentAsync(paymentId, amount, paymentStartedAt, deadline, transactionId, attempt + 1)
             null
         }
     }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -2,174 +2,253 @@ package ru.quipy.payments.logic
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
-import org.slf4j.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
+import ru.quipy.common.utils.CallerBlockingRejectedExecutionHandler
+import ru.quipy.common.utils.NamedThreadFactory
+import ru.quipy.common.utils.OngoingWindow
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.metrics.MetricsService
 import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.time.Duration
-import java.util.*
-import java.util.concurrent.Semaphore
+import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.max
 
-
-// Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
     val properties: PaymentAccountProperties,
     private val paymentESService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>,
     private val paymentProviderHostPort: String,
     private val token: String,
     private val metricsService: MetricsService,
+    private val dbScope: CoroutineScope,
 ) : PaymentExternalSystemAdapter {
 
     companion object {
-        val logger: Logger = LoggerFactory.getLogger(PaymentExternalSystemAdapter::class.java)
-
-        val emptyBody = ByteArray(0).toRequestBody(null)
+        val logger = LoggerFactory.getLogger(PaymentExternalSystemAdapter::class.java)
         val mapper = ObjectMapper().registerKotlinModule()
-        private const val TASK_NAME = "paymentTask"
     }
+
+    private val MAX_ATTEMPTS = 5
 
     private val serviceName = properties.serviceName
     private val accountName = properties.accountName
-    private val requestAverageProcessingTime = properties.averageProcessingTime
+    private val requestAverageProcessingTime = properties.averageProcessingTime.toMillis()
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), Duration.ofMillis(1000));
-    private val semaphore = Semaphore(parallelRequests)
-    private val timeout = Duration.ofMillis(1090)
-    private val client = OkHttpClient.Builder()
-        .callTimeout(timeout)
-        .connectTimeout(timeout)
-        .readTimeout(timeout)
-        .writeTimeout(timeout)
+    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), Duration.ofSeconds(1))
+    private val ongoingWindow = OngoingWindow(parallelRequests, false)
+    private val latencyProfile = RollingLatencyProfile(maxSize = 2048, fallbackMs = requestAverageProcessingTime.coerceAtLeast(20L))
+
+    private val httpThreadPoolSize = maxOf(100, parallelRequests / 10)
+    private val httpExecutor = ThreadPoolExecutor(
+        httpThreadPoolSize,
+        httpThreadPoolSize,
+        60L,
+        TimeUnit.SECONDS,
+        LinkedBlockingQueue(parallelRequests * 2),
+        Executors.defaultThreadFactory(),
+        CallerBlockingRejectedExecutionHandler(Duration.ofSeconds(5))
+    )
+
+    private val client: HttpClient = HttpClient.newBuilder()
+        .executor(httpExecutor)
+        .connectTimeout(Duration.ofMillis(1000L))
+        .version(HttpClient.Version.HTTP_2)
         .build()
 
-    override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+    override fun performPaymentAsync(paymentId: UUID, amount: Int, orderId: UUID, paymentStartedAt: Long, deadline: Long) {
+        logger.warn("[$accountName] Submitting payment request for payment $paymentId")
+
         val transactionId = UUID.randomUUID()
-        val start = System.currentTimeMillis()
-        val avgMs = requestAverageProcessingTime.toMillis()
-        val remaining = deadline - start
-        val maxRetries = 5
-        val timeout = 500L
 
-        logger.info("[$accountName] Submitting payment $paymentId (txId=$transactionId), remaining=${remaining}ms")
-
-        // Always record submission
-        paymentESService.update(paymentId) {
-            it.logSubmission(success = true, transactionId, now(), Duration.ofMillis(start - paymentStartedAt))
+        val startedAt = now()
+        dbScope.launch {
+            while (true) {
+                try {
+                    paymentESService.update(paymentId) {
+                        it.logSubmission(
+                            success = true,
+                            transactionId,
+                            startedAt,
+                            Duration.ofMillis(startedAt - paymentStartedAt)
+                        )
+                    }
+                    break
+                } catch (_: IllegalArgumentException) {
+                    delay(10)
+                }
+            }
         }
 
-        if (remaining < avgMs) {
-            logger.warn("[$accountName] Skipping payment $paymentId: remaining ${remaining}ms < avg ${avgMs}ms")
-            paymentESService.update(paymentId) {
-                it.logProcessing(false, now(), transactionId, reason = "Deadline too close")
+        logger.info("[$accountName] Submit: $paymentId , txId: $transactionId")
+        performPaymentAsync(paymentId, amount, paymentStartedAt, deadline, transactionId, 0)
+    }
+
+    private fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long, transactionId: UUID, attempt: Long) {
+        if (now() + requestAverageProcessingTime > deadline || attempt >= MAX_ATTEMPTS) {
+            metricsService.incrementCounter("payment_failed_external", "Failed external requests")
+            val currentTime = now()
+            dbScope.launch {
+                while (true) {
+                    try {
+                        paymentESService.update(paymentId) {
+                            it.logProcessing(false, currentTime, transactionId, reason = "Deadline exceeded or max attempts reached")
+                        }
+                        break
+                    } catch (_: IllegalArgumentException) {
+                        delay(10)
+                    }
+                }
             }
             return
         }
 
-        var attempt = 0
-        var success = false
-        var lastReason: String? = null
-
-        while (attempt < maxRetries && !success) {
-            attempt++
-
-            if (attempt > 1) {
-                metricsService.increaseRetryCounter()
-            }
-
-            val attemptStart = now()
-            val timeLeft = deadline - attemptStart
-
-            if (timeLeft < avgMs) {
-                logger.warn("[$accountName] Stop retrying payment $paymentId: deadline too close (${timeLeft}ms left)")
-                break
-            }
-
-            semaphore.acquire()
-            if (!rateLimiter.tick()) {
-                val retryDelay = timeout * attempt
-                logger.warn("[$accountName] Rate limited (attempt $attempt) delaying $retryDelay ms")
-                semaphore.release()
-                Thread.sleep(retryDelay)
-                continue
-            }
-
-            try {
-                val request = Request.Builder()
-                    .url(
-                        "http://$paymentProviderHostPort/external/process" +
-                                "?serviceName=$serviceName" +
-                                "&token=$token" +
-                                "&accountName=$accountName" +
-                                "&transactionId=$transactionId" +
-                                "&paymentId=$paymentId" +
-                                "&amount=$amount"
-                    )
-                    .post(emptyBody)
-                    .build()
-
-                client.newCall(request).execute().use { response ->
-                    val body = try {
-                        mapper.readValue(response.body?.string(), ExternalSysResponse::class.java)
-                    } catch (e: Exception) {
-                        logger.error("[$accountName] Failed to parse response: ${e.message}")
-                        ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
-                    }
-
-                    logger.info("CODE: ${response.code}")
-
-
-                    val duration = System.currentTimeMillis() - attemptStart
-                    metricsService.recordRequestDuration(duration, body.result)
-
-                    if (response.isSuccessful && body.result) {
-                        logger.info("[$accountName] Payment success for txId=$transactionId, payment=$paymentId")
-                        success = true
+        if (!rateLimiter.tickBlocking(Duration.ofMillis(deadline - now()))) {
+            metricsService.incrementCounter("payment_ratelimit_reject", "Rate limiter rejections")
+            val currentTime = now()
+            dbScope.launch {
+                while (true) {
+                    try {
                         paymentESService.update(paymentId) {
-                            it.logProcessing(true, now(), transactionId, reason = body.message)
+                            it.logProcessing(false, currentTime, transactionId, reason = "Rate limit exceed")
                         }
-                    } else {
-                        val retriable = isRetriable(null, response.code, body.message)
-                        lastReason = "HTTP ${response.code}: ${body.message}"
-                        logger.warn("[$accountName] Payment failed (attempt $attempt/$maxRetries): $lastReason, retriable=$retriable")
-
-                        if (!retriable) break
-
-                        val backoff = (timeout * attempt).coerceAtMost(timeLeft / 2)
-                        Thread.sleep(backoff)
+                        break
+                    } catch (_: IllegalArgumentException) {
+                        delay(10)
                     }
                 }
-                metricsService.incrementCompletedTask(TASK_NAME)
-            } catch (e: Exception) {
-                val retriable = isRetriable(e, null, e.message)
-                lastReason = e.message
-                logger.error("[$accountName] Exception during payment $paymentId: ${e.javaClass.simpleName}, retriable=$retriable", e)
-
-                if (!retriable) break
-
-                val backoff = (timeout * attempt).coerceAtMost((deadline - now()) / 2)
-                Thread.sleep(backoff)
-            } finally {
-                semaphore.release()
             }
+            return
         }
 
-        if (!success) {
-            paymentESService.update(paymentId) {
-                it.logProcessing(false, now(), transactionId, reason = lastReason ?: "Permanent failure")
+        val timeToBlock = deadline - System.currentTimeMillis()
+        val acquired = ongoingWindow.tryAcquire(timeToBlock, TimeUnit.MILLISECONDS)
+        if (!acquired) {
+            logger.warn("[$accountName] Timeout acquiring semaphore for payment $paymentId")
+            metricsService.incrementCounter("payment_semaphore_timeout", "Semaphore timeouts")
+            val currentTime = now()
+            dbScope.launch {
+                while (true) {
+                    try {
+                        paymentESService.update(paymentId) {
+                            it.logProcessing(false, currentTime, transactionId, reason = "Semaphore timeout")
+                        }
+                        break
+                    } catch (_: IllegalArgumentException) {
+                        delay(10)
+                    }
+                }
             }
+            return
+        }
+
+        val callTimeout = computeCallTimeoutMs(deadline - now())
+        val request = HttpRequest
+            .newBuilder()
+            .timeout(Duration.ofMillis(callTimeout))
+            .header("deadline", "$deadline")
+            .uri(URI("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount"))
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build()
+
+        val attemptStart = now()
+        client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
+            val duration = now() - attemptStart
+            latencyProfile.record(duration.coerceAtLeast(1))
+
+            val body = try {
+                mapper.readValue(response.body(), ExternalSysResponse::class.java)
+            } catch (e: Exception) {
+                logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.statusCode()}, reason: ${response.body()}")
+                ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
+            }
+            logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+
+            val currentTime = now()
+            val result = body.result
+            val message = body.message
+            dbScope.launch {
+                while (true) {
+                    try {
+                        paymentESService.update(paymentId) {
+                            it.logProcessing(result, currentTime, transactionId, reason = message)
+                        }
+                        break
+                    } catch (_: IllegalArgumentException) {
+                        delay(10)
+                    }
+                }
+            }
+
+            if (body.result) {
+                metricsService.incrementCounter("payment_success", "Successful payments")
+                ongoingWindow.release()
+            }
+            else {
+                metricsService.increaseRetryCounter()
+                ongoingWindow.release()
+
+                performPaymentAsync(paymentId, amount, paymentStartedAt, deadline, transactionId, attempt + 1)
+            }
+        }.exceptionally { ex ->
+            when (ex) {
+                is SocketTimeoutException -> {
+                    logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", ex)
+                    metricsService.incrementCounter("payment_failed_external", "Failed external requests")
+                    val currentTime = now()
+                    dbScope.launch {
+                        while (true) {
+                            try {
+                                paymentESService.update(paymentId) {
+                                    it.logProcessing(false, currentTime, transactionId, reason = "Request timeout.")
+                                }
+                                break
+                            } catch (_: IllegalArgumentException) {
+                                delay(10)
+                            }
+                        }
+                    }
+                }
+                else -> {
+                    logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", ex)
+                    metricsService.incrementCounter("payment_failed_external", "Failed external requests")
+                    val currentTime = now()
+                    dbScope.launch {
+                        while (true) {
+                            try {
+                                paymentESService.update(paymentId) {
+                                    it.logProcessing(false, currentTime, transactionId, reason = ex.message)
+                                }
+                                break
+                            } catch (_: IllegalArgumentException) {
+                                delay(10)
+                            }
+                        }
+                    }
+                }
+            }
+            metricsService.increaseRetryCounter()
+            ongoingWindow.release()
+
+            performPaymentAsync(paymentId, amount, paymentStartedAt, deadline, transactionId, attempt + 1)
+            null
         }
     }
-
-
 
     override fun price() = properties.price
 
@@ -177,26 +256,43 @@ class PaymentExternalSystemAdapterImpl(
 
     override fun name() = properties.accountName
 
+    override fun maxRateLimit() = properties.rateLimitPerSec
+
+    private fun computeCallTimeoutMs(timeLeft: Long): Long {
+        val p95 = latencyProfile.quantile(0.95)
+        val avg = requestAverageProcessingTime.coerceAtLeast(20L)
+        val target = max(avg, p95)
+        val adaptive = target.coerceAtLeast(150L).coerceAtMost(400L)
+        val boundedByDeadline = (timeLeft - 50L).coerceAtLeast(500L)
+        return adaptive.coerceAtMost(boundedByDeadline)
+    }
 }
 
-private fun isRetriable(e: Exception?, code: Int?, message: String?): Boolean {
-    if (e is SocketTimeoutException) return true
-    if (e is java.net.ConnectException) return true
-    if (e is java.net.SocketException) return true
+private class RollingLatencyProfile(
+    private val maxSize: Int,
+    private val fallbackMs: Long,
+    private val refreshInterval: Int = 64,
+) {
+    private val samples = ConcurrentLinkedDeque<Long>()
+    private val recordCount = AtomicInteger(0)
+    @Volatile private var cachedSorted: LongArray = LongArray(0)
 
-    if(message?.contains("Temporary error", ignoreCase = true) == true) return true
-
-    if (code != null) {
-        return when (code) {
-            429,
-            in 500..599 -> true
-            else -> false
+    fun record(durationMs: Long) {
+        samples.addLast(durationMs.coerceAtLeast(1L))
+        while (samples.size > maxSize) {
+            samples.pollFirst()
+        }
+        if (recordCount.incrementAndGet() % refreshInterval == 0) {
+            cachedSorted = samples.toList().toLongArray().also { it.sort() }
         }
     }
 
-    if (message?.contains("timeout", ignoreCase = true) == true) return true
-    return false
+    fun quantile(q: Double): Long {
+        val sorted = cachedSorted
+        if (sorted.isEmpty()) return fallbackMs
+        val index = ((sorted.size - 1) * q).toInt().coerceIn(0, sorted.lastIndex)
+        return sorted[index]
+    }
 }
-
 
 public fun now() = System.currentTimeMillis()

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -50,8 +50,8 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), Duration.ofSeconds(1))
-    private val ongoingWindow = OngoingWindow(parallelRequests, false)
+    private val rateLimiter = SlidingWindowRateLimiter((rateLimitPerSec * 19L / 20), Duration.ofSeconds(1))
+    private val ongoingWindow = OngoingWindow(parallelRequests * 19 / 20, false)
     private val latencyProfile = RollingLatencyProfile(maxSize = 2048, fallbackMs = requestAverageProcessingTime.coerceAtLeast(20L))
 
     private val httpThreadPoolSize = maxOf(100, parallelRequests / 10)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -50,8 +50,8 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val rateLimiter = SlidingWindowRateLimiter((rateLimitPerSec * 19L / 20), Duration.ofSeconds(1))
-    private val ongoingWindow = OngoingWindow(parallelRequests * 19 / 20, false)
+    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), Duration.ofSeconds(1))
+    private val ongoingWindow = OngoingWindow(parallelRequests, false)
     private val latencyProfile = RollingLatencyProfile(maxSize = 2048, fallbackMs = requestAverageProcessingTime.coerceAtLeast(20L))
 
     private val httpThreadPoolSize = maxOf(100, parallelRequests / 10)
@@ -262,7 +262,7 @@ class PaymentExternalSystemAdapterImpl(
         val p95 = latencyProfile.quantile(0.95)
         val avg = requestAverageProcessingTime.coerceAtLeast(20L)
         val target = max(avg, p95)
-        val adaptive = target.coerceAtLeast(150L).coerceAtMost(400L)
+        val adaptive = target.coerceAtLeast(150L).coerceAtMost(800L)
         val boundedByDeadline = (timeLeft - 50L).coerceAtLeast(500L)
         return adaptive.coerceAtMost(boundedByDeadline)
     }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
@@ -4,10 +4,8 @@ import java.time.Duration
 import java.util.*
 
 interface PaymentService {
-    /**
-     * Submit payment request to some external service.
-     */
-    fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
+    fun submitPaymentRequest(paymentId: UUID, amount: Int, orderId: UUID, paymentStartedAt: Long, deadline: Long)
+    fun getMaxRateLimit(): Int
 }
 
 /**
@@ -17,13 +15,14 @@ interface PaymentService {
 
  */
 interface PaymentExternalSystemAdapter {
-    fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
+    fun performPaymentAsync(paymentId: UUID, amount: Int, orderId: UUID, paymentStartedAt: Long, deadline: Long)
 
     fun name(): String
 
     fun price(): Int
 
     fun isEnabled(): Boolean
+    fun maxRateLimit(): Int
 }
 
 /**

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
@@ -13,9 +13,13 @@ class PaymentSystemImpl(
         val logger = LoggerFactory.getLogger(PaymentSystemImpl::class.java)
     }
 
-    override fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+    override fun submitPaymentRequest(paymentId: UUID, amount: Int, orderId: UUID, paymentStartedAt: Long, deadline: Long) {
         for (account in paymentAccounts) {
-            account.performPaymentAsync(paymentId, amount, paymentStartedAt, deadline)
+            account.performPaymentAsync(paymentId, amount, orderId, paymentStartedAt, deadline)
         }
+    }
+
+    override fun getMaxRateLimit(): Int {
+        return paymentAccounts.filter { it.isEnabled() }.sumOf { it.maxRateLimit() }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,9 @@ server.address=0.0.0.0
 server.port=8081
 server.http2.enabled=true
 spring.main.allow-bean-definition-overriding=true
+spring.threads.virtual.enabled=false
+server.jetty.threads.max=2000
+server.jetty.threads.min=200
 
 # MongoDB properties
 spring.data.mongodb.host=localhost
@@ -18,7 +21,10 @@ event.sourcing.sagas-enabled=false
 spring.datasource.hikari.jdbc-url=jdbc:postgresql://${POSTGRES_ADDRESS:localhost}:${POSTGRES_PORT:65432}/postgres
 spring.datasource.hikari.username=tiny_es
 spring.datasource.hikari.password=tiny_es
-spring.datasource.hikari.leak-detection-threshold=2000
+spring.datasource.hikari.maximumPoolSize=400
+spring.datasource.hikari.minimumIdle=400
+spring.datasource.hikari.connectionTimeout=500
+spring.datasource.hikari.leakDetectionThreshold=2000
 
 management.metrics.web.server.request.autotime.percentiles=0.95
 management.metrics.export.prometheus.enabled=true
@@ -26,7 +32,7 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=${PAYMENT_ACCOUNTS:acc-7}
+payment.accounts=${PAYMENT_ACCOUNTS:acc-13}
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}
 
 metrics.incoming-requests.name=i_requests


### PR DESCRIPTION
Что помогло решить проблему:
* Выделен отдельный CoroutineScope с 200 потоками для асинхронной работы с БД – разгрузил основные потоки от блокирующих операций.
* Использован client.sendAsync с коллбэками – теперь HTTP-вызовы не блокируют потоки, а утилизация ресурсов стала эффективнее.
* Введён RollingLatencyProfile, который рассчитывает таймаут вызова на основе p95 реальных задержек. Это критично для processingTimeMillis=1000: при высокой нагрузке таймаут подстраивается под фактическую latency, избегая преждевременных ошибок или излишне долгих ожиданий.

http://77.234.215.138:33000/d/KVr-Vmpnz/services-statistic?orgId=1&from=2026-03-06T11:07:23.358Z&to=2026-03-06T11:32:32.181Z&timezone=browser&var-service=Reability-Disability&refresh=5s