### PR TITLE
Hw 11

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -31,7 +31,7 @@ class APIController(
     @PostConstruct
     fun init() {
         val limit = orderPayer.getMaxRateLimit()
-        this.rateLimiter = SlidingWindowRateLimiter((limit * 4L / 5) / 10, Duration.ofMillis(100))
+        this.rateLimiter = SlidingWindowRateLimiter(limit * 4L / 5, Duration.ofMillis(1000))
     }
 
     @PostMapping("/users")

--- a/src/main/kotlin/ru/quipy/apigateway/APIController.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/APIController.kt
@@ -71,12 +71,6 @@ class APIController(
 
     @PostMapping("/orders/{orderId}/payment")
     suspend fun payOrder(@PathVariable orderId: UUID, @RequestParam deadline: Long): ResponseEntity<PaymentSubmissionDto> {
-        if (!rateLimiter.tick()) {
-            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
-                .header("Retry-After", 1.toString())
-                .build()
-        }
-
         val paymentId = UUID.randomUUID()
         val order = orderRepository.findById(orderId)?.let {
             orderRepository.save(it.copy(status = OrderStatus.PAYMENT_IN_PROGRESS))

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -164,9 +164,14 @@ class PaymentExternalSystemAdapterImpl(
         // Try to acquire a second semaphore slot for a hedged parallel request.
         val hedge1TxId = UUID.randomUUID()
         val hedge2TxId = UUID.randomUUID()
+        val hedge3TxId = UUID.randomUUID()
         val hedge1Acquired = ongoingWindow.tryAcquire(30, TimeUnit.MILLISECONDS)
         val hedge2Acquired = if (hedge1Acquired) ongoingWindow.tryAcquire(30, TimeUnit.MILLISECONDS) else false
-        val hedgeCount = 1 + (if (hedge1Acquired) 1 else 0) + (if (hedge2Acquired) 1 else 0)
+        val hedge3Acquired = if (hedge2Acquired) ongoingWindow.tryAcquire(30, TimeUnit.MILLISECONDS) else false
+        val hedgeCount = 1 +
+            (if (hedge1Acquired) 1 else 0) +
+            (if (hedge2Acquired) 1 else 0) +
+            (if (hedge3Acquired) 1 else 0)
         val pendingFailures = AtomicInteger(hedgeCount)
         val won = AtomicBoolean(false)
 
@@ -256,6 +261,10 @@ class PaymentExternalSystemAdapterImpl(
         if (hedge2Acquired) {
             client.sendAsync(buildHttpRequest(hedge2TxId), HttpResponse.BodyHandlers.ofString())
                 .whenComplete { response, ex -> onComplete(response, ex, hedge2TxId) }
+        }
+        if (hedge3Acquired) {
+            client.sendAsync(buildHttpRequest(hedge3TxId), HttpResponse.BodyHandlers.ofString())
+                .whenComplete { response, ex -> onComplete(response, ex, hedge3TxId) }
         }
     }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -100,7 +100,7 @@ class PaymentExternalSystemAdapterImpl(
     }
 
     private fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long, transactionId: UUID, attempt: Long) {
-        if (now() + requestAverageProcessingTime > deadline || attempt >= MAX_ATTEMPTS) {
+        if (now() >= deadline || attempt >= MAX_ATTEMPTS) {
             metricsService.incrementCounter("payment_failed_external", "Failed external requests")
             val currentTime = now()
             dbScope.launch {
@@ -254,7 +254,7 @@ class PaymentExternalSystemAdapterImpl(
         val p95 = latencyProfile.quantile(0.95)
         val avg = requestAverageProcessingTime.coerceAtLeast(20L)
         val target = max(avg, p95)
-        val adaptive = target.coerceAtLeast(150L).coerceAtMost(800L)
+        val adaptive = target.coerceAtLeast(150L)
         val boundedByDeadline = (timeLeft - 50L).coerceAtLeast(500L)
         return adaptive.coerceAtMost(boundedByDeadline)
     }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.max
 
 class PaymentExternalSystemAdapterImpl(
@@ -157,79 +158,76 @@ class PaymentExternalSystemAdapterImpl(
             return
         }
 
+        val attemptStart = now()
         val callTimeout = computeCallTimeoutMs(deadline - now())
-        val request = HttpRequest
+
+        // Try to acquire a second semaphore slot for a hedged parallel request.
+        val hedgedTransactionId = UUID.randomUUID()
+        val hedgeAcquired = ongoingWindow.tryAcquire(30, TimeUnit.MILLISECONDS)
+        val pendingFailures = AtomicInteger(if (hedgeAcquired) 2 else 1)
+        val won = AtomicBoolean(false)
+
+        fun buildHttpRequest(txId: UUID): HttpRequest = HttpRequest
             .newBuilder()
             .timeout(Duration.ofMillis(callTimeout))
             .header("deadline", "$deadline")
-            .uri(URI("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$transactionId&paymentId=$paymentId&amount=$amount"))
+            .uri(URI("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=$txId&paymentId=$paymentId&amount=$amount"))
             .POST(HttpRequest.BodyPublishers.noBody())
             .build()
 
-        val attemptStart = now()
-        client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
-            val duration = now() - attemptStart
-            latencyProfile.record(duration.coerceAtLeast(1))
+        fun onComplete(response: HttpResponse<String>?, ex: Throwable?, txId: UUID) {
+            if (ex != null) {
+                ongoingWindow.release()
+                val cause = (ex as? java.util.concurrent.CompletionException)?.cause ?: ex
+                logger.error("[$accountName] Payment exception for txId: $txId, payment: $paymentId", cause)
+                metricsService.incrementCounter("payment_failed_external", "Failed external requests")
 
-            val body = try {
-                mapper.readValue(response.body(), ExternalSysResponse::class.java)
-            } catch (e: Exception) {
-                logger.error("[$accountName] [ERROR] Payment processed for txId: $transactionId, payment: $paymentId, result code: ${response.statusCode()}, reason: ${response.body()}")
-                ExternalSysResponse(transactionId.toString(), paymentId.toString(), false, e.message)
-            }
-            logger.warn("[$accountName] Payment processed for txId: $transactionId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
-
-            val currentTime = now()
-            val result = body.result
-            val message = body.message
-            dbScope.launch {
-                while (true) {
-                    try {
-                        paymentESService.update(paymentId) {
-                            it.logProcessing(result, currentTime, transactionId, reason = message)
+                if (pendingFailures.decrementAndGet() == 0 && !won.get()) {
+                    val willRetry = attempt + 1 < MAX_ATTEMPTS && now() < deadline
+                    if (willRetry) {
+                        metricsService.increaseRetryCounter()
+                        performPaymentAsync(paymentId, amount, paymentStartedAt, deadline, transactionId, attempt + 1)
+                    } else {
+                        val currentTime = now()
+                        val reason = if (cause is SocketTimeoutException) "Request timeout." else cause.message
+                        dbScope.launch {
+                            while (true) {
+                                try {
+                                    paymentESService.update(paymentId) {
+                                        it.logProcessing(false, currentTime, transactionId, reason = reason)
+                                    }
+                                    break
+                                } catch (_: IllegalArgumentException) {
+                                    delay(10)
+                                }
+                            }
                         }
-                        break
-                    } catch (_: IllegalArgumentException) {
-                        delay(10)
                     }
                 }
+                return
             }
 
-            if (body.result) {
-                metricsService.incrementCounter("payment_success", "Successful payments")
-                ongoingWindow.release()
-            }
-            else {
-                metricsService.increaseRetryCounter()
-                ongoingWindow.release()
-
-                performPaymentAsync(paymentId, amount, paymentStartedAt, deadline, transactionId, attempt + 1)
-            }
-        }.exceptionally { ex ->
-            val willRetry = attempt + 1 < MAX_ATTEMPTS && now() + requestAverageProcessingTime <= deadline
-            when (ex) {
-                is SocketTimeoutException -> {
-                    logger.error("[$accountName] Payment timeout for txId: $transactionId, payment: $paymentId", ex)
-                    metricsService.incrementCounter("payment_failed_external", "Failed external requests")
-                }
-                else -> {
-                    logger.error("[$accountName] Payment failed for txId: $transactionId, payment: $paymentId", ex)
-                    metricsService.incrementCounter("payment_failed_external", "Failed external requests")
-                }
-            }
+            val duration = now() - attemptStart
+            latencyProfile.record(duration.coerceAtLeast(1))
             ongoingWindow.release()
 
-            if (willRetry) {
-                metricsService.increaseRetryCounter()
-                performPaymentAsync(paymentId, amount, paymentStartedAt, deadline, transactionId, attempt + 1)
-            } else {
+            val body = try {
+                mapper.readValue(response!!.body(), ExternalSysResponse::class.java)
+            } catch (e: Exception) {
+                logger.error("[$accountName] [ERROR] Payment parse error for txId: $txId, payment: $paymentId, code: ${response!!.statusCode()}")
+                ExternalSysResponse(txId.toString(), paymentId.toString(), false, e.message)
+            }
+            logger.warn("[$accountName] Payment for txId: $txId, payment: $paymentId, succeeded: ${body.result}, message: ${body.message}")
+
+            if (body.result && won.compareAndSet(false, true)) {
+                // First success wins — write to ES exactly once.
+                metricsService.incrementCounter("payment_success", "Successful payments")
                 val currentTime = now()
-                val reason = if (ex is SocketTimeoutException) "Request timeout." else ex.message
                 dbScope.launch {
                     while (true) {
                         try {
                             paymentESService.update(paymentId) {
-                                it.logProcessing(false, currentTime, transactionId, reason = reason)
+                                it.logProcessing(true, currentTime, txId, reason = body.message)
                             }
                             break
                         } catch (_: IllegalArgumentException) {
@@ -237,8 +235,20 @@ class PaymentExternalSystemAdapterImpl(
                         }
                     }
                 }
+            } else if (!body.result && pendingFailures.decrementAndGet() == 0 && !won.get()) {
+                // All hedged requests returned failure — retry.
+                metricsService.increaseRetryCounter()
+                performPaymentAsync(paymentId, amount, paymentStartedAt, deadline, transactionId, attempt + 1)
             }
-            null
+            // If body.result==true but won.compareAndSet failed: another request already won, ignore.
+        }
+
+        client.sendAsync(buildHttpRequest(transactionId), HttpResponse.BodyHandlers.ofString())
+            .whenComplete { response, ex -> onComplete(response, ex, transactionId) }
+
+        if (hedgeAcquired) {
+            client.sendAsync(buildHttpRequest(hedgedTransactionId), HttpResponse.BodyHandlers.ofString())
+                .whenComplete { response, ex -> onComplete(response, ex, hedgedTransactionId) }
         }
     }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -162,9 +162,12 @@ class PaymentExternalSystemAdapterImpl(
         val callTimeout = computeCallTimeoutMs(deadline - now())
 
         // Try to acquire a second semaphore slot for a hedged parallel request.
-        val hedgedTransactionId = UUID.randomUUID()
-        val hedgeAcquired = ongoingWindow.tryAcquire(30, TimeUnit.MILLISECONDS)
-        val pendingFailures = AtomicInteger(if (hedgeAcquired) 2 else 1)
+        val hedge1TxId = UUID.randomUUID()
+        val hedge2TxId = UUID.randomUUID()
+        val hedge1Acquired = ongoingWindow.tryAcquire(30, TimeUnit.MILLISECONDS)
+        val hedge2Acquired = if (hedge1Acquired) ongoingWindow.tryAcquire(30, TimeUnit.MILLISECONDS) else false
+        val hedgeCount = 1 + (if (hedge1Acquired) 1 else 0) + (if (hedge2Acquired) 1 else 0)
+        val pendingFailures = AtomicInteger(hedgeCount)
         val won = AtomicBoolean(false)
 
         fun buildHttpRequest(txId: UUID): HttpRequest = HttpRequest
@@ -245,10 +248,14 @@ class PaymentExternalSystemAdapterImpl(
 
         client.sendAsync(buildHttpRequest(transactionId), HttpResponse.BodyHandlers.ofString())
             .whenComplete { response, ex -> onComplete(response, ex, transactionId) }
-
-        if (hedgeAcquired) {
-            client.sendAsync(buildHttpRequest(hedgedTransactionId), HttpResponse.BodyHandlers.ofString())
-                .whenComplete { response, ex -> onComplete(response, ex, hedgedTransactionId) }
+        
+        if (hedge1Acquired) {
+            client.sendAsync(buildHttpRequest(hedge1TxId), HttpResponse.BodyHandlers.ofString())
+                .whenComplete { response, ex -> onComplete(response, ex, hedge1TxId) }
+        }
+        if (hedge2Acquired) {
+            client.sendAsync(buildHttpRequest(hedge2TxId), HttpResponse.BodyHandlers.ofString())
+                .whenComplete { response, ex -> onComplete(response, ex, hedge2TxId) }
         }
     }
 


### PR DESCRIPTION
Посмотрели на показатели аккаунта и данные теста. Поняли , что сильно урезаны во времени: запрос может исполняться дольше, чем клиент готов ждать. Для решения проблемы:
* Убрали некоторые ограничения по количеству запросов.
* Настроили верный расчёт времени (чтобы все запросы не улетали сразу в 429.
* Добавили hedge-запросы. 

<img width="1738" height="824" alt="image" src="https://github.com/user-attachments/assets/aa09fa0b-bf94-442f-81fa-4b9943ca2260" />
